### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+composer.lock
+.phpunit.result.cache
+.idea/
+.vscode/

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,17 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "dreamfactory/df-oauth": "~0.16",
+    "php": "^8.3",
+    "laravel/helpers": "^1.8",
+    "dreamfactory/df-oauth": "~1.0",
     "phpseclib/phpseclib": "3.0.*"
+  },
+  "require-dev": {
+    "laravel/framework": "^13.7",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3",
+    "orchestra/testbench": "^11.0"
   },
   "autoload":    {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Security">
+            <directory>tests/Security</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Components/OidcProvider.php
+++ b/src/Components/OidcProvider.php
@@ -214,6 +214,18 @@ class OidcProvider extends AbstractProvider
     {
         $idToken = Arr::get($response, 'id_token');
 
+        // Always validate when an id_token is present. The previous behavior
+        // had an `elseif (!empty($idToken))` branch that returned the raw
+        // base64-decoded JWT payload WITHOUT verifying signature, issuer,
+        // audience, or expiry — meaning a forged id_token from any source
+        // (or an unsigned JWT) would be accepted and its claims trusted to
+        // populate the user record. Removed.
+        //
+        // When validation is configured (validateIdToken=true and jwksUri
+        // set), we run the full check. Otherwise we DO NOT trust the
+        // id_token payload at all — getUserFromTokenResponse() falls back
+        // to calling the userinfo endpoint with the access_token, which
+        // is authenticated server-to-server.
         if ($this->validateIdToken === true) {
             if (empty($this->jwksUri)) {
                 throw new InternalServerErrorException('Token validation is turned on but no JWKS URI found. Please check your service configuration.');
@@ -227,18 +239,19 @@ class OidcProvider extends AbstractProvider
             $this->verifyExpiry(Arr::get($payload, 'exp'));
 
             return $payload;
-        } elseif (!empty($idToken)) {
-            $parts = explode('.', $idToken);
-            if (count($parts) !== 3) {
-                throw new InternalServerErrorException('Cannot get JWT header. Incorrect number of segments in JWT.');
-            }
+        }
 
-            return json_decode($this->encoder->decode($parts[1]), true);
+        if (!empty($idToken)) {
+            Log::warning(
+                'OIDC id_token received but validateIdToken is disabled or jwksUri unset; '
+                . 'id_token claims will NOT be trusted. Falling back to userinfo endpoint. '
+                . 'Enable validateIdToken + configure jwksUri to consume id_token claims directly.'
+            );
         } else {
             Log::warning('No ID Token found for OpenID Connect service.');
-
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/src/Components/OidcProvider.php
+++ b/src/Components/OidcProvider.php
@@ -377,11 +377,24 @@ class OidcProvider extends AbstractProvider
      * @throws \DreamFactory\Core\Exceptions\InternalServerErrorException
      * @throws \DreamFactory\Core\Exceptions\UnauthorizedException
      */
+    /**
+     * Algorithms accepted from the JWKS document. We deliberately reject
+     * 'none', HMAC variants (HS*), and anything else not on this list:
+     * a malicious or compromised JWKS could otherwise downgrade verification
+     * (alg=none) or trigger HMAC/RSA confusion.
+     */
+    public const ALLOWED_JWS_ALGS = ['RS256', 'RS384', 'RS512'];
+
     protected function verifySignature($keyData, $idToken)
     {
         try {
             $kty = Arr::get($keyData, 'kty');
             $alg = Arr::get($keyData, 'alg', 'RS256');
+            if (!in_array($alg, self::ALLOWED_JWS_ALGS, true)) {
+                throw new InternalServerErrorException(
+                    'Failed to verify JWT signature. Disallowed algorithm [' . $alg . '].'
+                );
+            }
             if ($kty === 'RSA') {
                 $modulus = new BigInteger($this->encoder->decode($keyData['n']), (int)substr($alg, 2));
                 $exponent = new BigInteger($this->encoder->decode($keyData['e']), (int)substr($alg, 2));

--- a/tests/Security/IdTokenValidationTest.php
+++ b/tests/Security/IdTokenValidationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace DreamFactory\Core\OIDC\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: OidcProvider::validateIdToken() must NOT decode and trust the
+ * id_token payload without signature/issuer/audience/expiry verification.
+ *
+ * Phase 2 audit found:
+ *
+ *     if ($this->validateIdToken === true) { ...full validation... }
+ *     elseif (!empty($idToken)) {
+ *         $parts = explode('.', $idToken);
+ *         return json_decode($this->encoder->decode($parts[1]), true);  // <-- accept any forged claims
+ *     }
+ *
+ * The `elseif` branch returned the raw base64-decoded JWT payload without
+ * verifying the signature. Any caller (or any IdP, including a forged
+ * response) could mint claims (sub, email, roles) that DreamFactory then
+ * used to identify or provision a user.
+ *
+ * After the fix, when validateIdToken is disabled or jwksUri unset, the
+ * id_token claims are NEVER consumed. getUserFromTokenResponse() falls back
+ * to calling the userinfo endpoint with the access_token, which is
+ * authenticated server-to-server.
+ */
+class IdTokenValidationTest extends TestCase
+{
+    private string $sourcePath;
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $this->sourcePath = __DIR__ . '/../../src/Components/OidcProvider.php';
+        $this->assertFileExists($this->sourcePath);
+        $this->contents = file_get_contents($this->sourcePath);
+    }
+
+    /**
+     * Slice the body of validateIdToken(array $response).
+     */
+    private function methodBody(): string
+    {
+        $start = strpos($this->contents, 'function validateIdToken(array');
+        $this->assertNotFalse($start, 'validateIdToken(array $response) must exist');
+        $next = strpos($this->contents, "\n    /**", $start + 10);
+        return substr($this->contents, $start, $next === false ? null : ($next - $start));
+    }
+
+    public function testNoUnverifiedJsonDecodeOfIdToken(): void
+    {
+        $body = $this->methodBody();
+        // The vulnerable shape was:
+        //   return json_decode($this->encoder->decode($parts[1]), true);
+        // Forbid that entire pattern.
+        $this->assertDoesNotMatchRegularExpression(
+            '/json_decode\s*\(\s*\$this->encoder->decode\s*\(\s*\$parts\[1\]\s*\)/',
+            $body,
+            'validateIdToken() must not decode + return the raw JWT payload '
+            . 'when signature validation is disabled. The id_token claims must '
+            . 'NEVER be trusted without verification.'
+        );
+    }
+
+    public function testReturnsNullOrCallsValidationWhenIdTokenPresent(): void
+    {
+        $body = $this->methodBody();
+
+        // After the fix, the disabled-validation branch must either
+        // (a) return null when id_token is present (preferred — falls back to userinfo)
+        // (b) throw an exception; or
+        // (c) call full verification.
+        // Forbid: returning the parsed payload as a value the caller will trust.
+        $this->assertDoesNotMatchRegularExpression(
+            '/return\s+json_decode\s*\(/',
+            $body,
+            'validateIdToken() must not return a json_decode result of the JWT payload'
+        );
+    }
+}

--- a/tests/Security/JwksAlgAllowlistTest.php
+++ b/tests/Security/JwksAlgAllowlistTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace DreamFactory\Core\OIDC\Tests\Security;
+
+use DreamFactory\Core\Oidc\Components\OidcProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: only RSA SHA-2 algorithms are accepted from the JWKS doc.
+ * Reject 'none', HMAC variants, or anything else that could downgrade
+ * verification or trigger alg confusion.
+ */
+class JwksAlgAllowlistTest extends TestCase
+{
+    public function testAllowlistContainsRsaSha2Only(): void
+    {
+        $this->assertSame(
+            ['RS256', 'RS384', 'RS512'],
+            OidcProvider::ALLOWED_JWS_ALGS,
+            'JWKS alg allowlist must be exactly RS256/RS384/RS512'
+        );
+    }
+
+    public function testNoneAlgIsRejected(): void
+    {
+        $this->assertNotContains('none', OidcProvider::ALLOWED_JWS_ALGS);
+        $this->assertNotContains('None', OidcProvider::ALLOWED_JWS_ALGS);
+    }
+
+    public function testHmacAlgsAreRejected(): void
+    {
+        foreach (['HS256', 'HS384', 'HS512'] as $alg) {
+            $this->assertNotContains($alg, OidcProvider::ALLOWED_JWS_ALGS);
+        }
+    }
+
+    public function testEcdsaAlgsAreRejected(): void
+    {
+        // ES256/384/512 are not currently supported by the verifier
+        // (uses RSA-only path); ensure they are not silently allowlisted.
+        foreach (['ES256', 'ES384', 'ES512'] as $alg) {
+            $this->assertNotContains($alg, OidcProvider::ALLOWED_JWS_ALGS);
+        }
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master (NOTE: master ahead of develop)

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

> ⚠️ `master` has commits not in `develop` — listed below. GitHub will
> create a merge commit; both histories are preserved. Reviewer:
> verify the divergent master commits aren't logically conflicting
> with the develop work before merging.

### Verification

The develop HEAD here is the SHA locked into the L13/PHP 8.5 test
bundle. **Full end-to-end smoke passed 2026-05-26** (PHP 8.5.5,
Laravel 13.11.2, df:setup, login, CRUD, OpenAPI gen).

### Coordinated release PRs

One of ~26 coordinated release PRs. Merge order:
foundation → connectors → auth → services → AI → admin UI → host app.
